### PR TITLE
修复 Files API 的若干问题

### DIFF
--- a/src/main/express/controllers/files.ts
+++ b/src/main/express/controllers/files.ts
@@ -1,4 +1,5 @@
 import fs from 'fs';
+import fsp from 'fs/promises';
 import { resolve } from 'path';
 import { FileType } from '@/main/express/types';
 import { FileStateApi } from '@/common/types';
@@ -68,7 +69,7 @@ export const Rename = (req: Request, res: Response) => {
       });
   }
 
-  fs.rename(path, newPath)
+  fsp.rename(path, newPath)
     .then(() => {
       res.json({
         msg: 'ok',
@@ -86,7 +87,7 @@ export const Rename = (req: Request, res: Response) => {
 export const Write = (req: Request, res: Response) => {
   const { path, content } = req.body;
 
-  fs.writeFile(path, content, { encoding: 'utf8' })
+  fsp.writeFile(path, content, { encoding: 'utf8' })
     .then(() => {
       res.json({
         msg: 'ok',


### PR DESCRIPTION
- 在 Node 中, fs 的方法都 (至少表面上是) 同步的, 不会返回 Promise, 这会造成编译错误. import 'fs/promises' 模块可使用其提供的返回 Promise 的方法.
- Files API 的中间件中有一些关于路径合法性检验的冗余代码. 将其修改以优化.
- Files API 中的 Rename 一节有一个参数 newPath, 性质与 path 相同但未经验证. 增添了缺失的验证环节.